### PR TITLE
Fixes for releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Go
+name: Release
 
 on:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,9 @@ jobs:
         run: |
           make install
 
-      - name: Release
+      - name: Releaseenv:
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           make clean
 

--- a/Makefile
+++ b/Makefile
@@ -81,10 +81,10 @@ test-gen-mock: ## Generate the mocks
 	@mockgen -source client/client.go > mock_client/mock_client.go
 
 .PHONY: all ## Run everything
-all: clean install vet build test
+all: clean install lint build test
 
 .PHONY: static-all ## Run everything
-static-all: clean install vet static test
+static-all: clean install lint static test
 
 .PHONY: docker-build
 docker-build:


### PR DESCRIPTION
- Fix the static error for building docker images.
- Update the name of the release workflow
- Add the secret so we can use `gh`.
